### PR TITLE
Ft/#10 fix vuerouter history mode

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -7,6 +7,7 @@ Vue.use(VueRouter)
 export default new VueRouter({
   routes: [
     {
+      mode:'history',
       path: '/',
       name: 'home',
       component: Home

--- a/src/router.js
+++ b/src/router.js
@@ -1,10 +1,10 @@
 import Vue from 'vue'
-import Router from 'vue-router'
+import VueRouter from 'vue-router'
 import Home from './views/Home.vue'
 
-Vue.use(Router)
+Vue.use(VueRouter)
 
-export default new Router({
+export default new VueRouter({
   routes: [
     {
       path: '/',


### PR DESCRIPTION
Fix for #10.

First, it replaces Router with VueRouter, as per the examples in the docs: https://router.vuejs.org/guide/essentials/history-mode.html#example-server-configurations

Secondly, it applies the history mode (as suggested in the issue description). This overrides the default behaviour of the hash in the URL.