### PR TITLE
Added the year '2019' to references where Orbtoberfest is mentioned

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -53,7 +53,7 @@
           <h1>What you win</h1>
           <p>If you submit at least four valid PRs you will earn a limited-edition Hacktoberfest T-shirt from DigitalOcean.</p>
           <h2>Bonus:</h2>
-          <p>Participate in <span class="fancyText">#Orbtoberfest 2019</span> with CircleCI and claim limited edition swag!</p>
+          <p>Participate in <span class="fancyText">#Orbtoberfest</span> 2019 with CircleCI and claim limited edition swag!</p>
           <ul>
             <li>1 - 3 pull requests: Limited-Edition Sticker</li>
             <li>4+ pull requests: Limited-Edition T-shirt</li>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -53,7 +53,7 @@
           <h1>What you win</h1>
           <p>If you submit at least four valid PRs you will earn a limited-edition Hacktoberfest T-shirt from DigitalOcean.</p>
           <h2>Bonus:</h2>
-          <p>Participate in <span class="fancyText">#Orbtoberfest</span> with CircleCI and claim limited edition swag!</p>
+          <p>Participate in <span class="fancyText">#Orbtoberfest 2019</span> with CircleCI and claim limited edition swag!</p>
           <ul>
             <li>1 - 3 pull requests: Limited-Edition Sticker</li>
             <li>4+ pull requests: Limited-Edition T-shirt</li>
@@ -62,12 +62,12 @@
           <a href="https://docs.google.com/forms/d/1-MbzLy0m1eRLjeye9wu76fYkzcX5A3PvgKd09EhVObY/viewform" class="ctaButton">Enter your PRs</a>
         </div>
         <figure class="col heroImage" id="swagCol">
-          <img src="@/assets/hacktober19_swag-mockup.png" alt="CircleCI Orbtoberfest">
+          <img src="@/assets/hacktober19_swag-mockup.png" alt="CircleCI Orbtoberfest 2019">
         </figure>
       </div>
     </article>
     <article class="col hero container">
-      <h1>Participating in Orbtoberfest on CircleCI</h1>
+      <h1>Participating in Orbtoberfest 2019 on CircleCI</h1>
       <div class="row">
         <div class="col desktop-left">
           <p>Contributing to <a href="https://circleci.com/orbs/">CircleCI orbs</a> is one easy way to complete the Hacktoberfest challenge. CircleCI orbs are open source, reusable packages of config that can help speed up development and connect your favorite tools to your CI pipeline. </p>


### PR DESCRIPTION
Added the current year after references to Orbtoberfest so that users visiting the website will know what year the current version of the website is for. Fixes #7 